### PR TITLE
fix warning and error dialog message handling

### DIFF
--- a/Shanty.cpp
+++ b/Shanty.cpp
@@ -747,7 +747,7 @@ Shanty::MessageReceived(BMessage* message)
 	
 		switch (fResponseType) {
 			
-			case kInfo: kWarning: kError:
+			case kInfo: case kWarning: case kError:
 					what = MSG_OK_CLICKED;
 	
 					break;


### PR DESCRIPTION
Without the 'case' keyword the symbols are treated as labels for a 'goto' command.  This was preventing --error and --warning dialogs from exiting after the user had pressed OK.